### PR TITLE
Allow blank dates to be set for nil date inputs

### DIFF
--- a/lib/just-datetime-picker/databases/common.rb
+++ b/lib/just-datetime-picker/databases/common.rb
@@ -97,6 +97,9 @@ module Just
 
           protected
           def just_combine_datetime(field_name)
+            if instance_variable_get("@#{field_name}_date").nil?
+                self.send("#{field_name}=", '')
+            end
             if not instance_variable_get("@#{field_name}_date").nil? and not instance_variable_get("@#{field_name}_time_hour").nil? and not instance_variable_get("@#{field_name}_time_minute").nil?
 
               combined = "#{instance_variable_get("@#{field_name}_date")} #{sprintf("%02d", instance_variable_get("@#{field_name}_time_hour"))}:#{sprintf("%02d", instance_variable_get("@#{field_name}_time_minute"))}:00"


### PR DESCRIPTION
Currently, just_combine method only combines and sets attribute for the date if date, hour or min is not null. The pull request allows a empty date to actually be pass back to the model to be set as an empty field.
