### PR TITLE
Consider options when initializing date pickers

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -140,6 +140,7 @@ This code is licensed under GPLv3[http://www.gnu.org/licenses/gpl.html].
 
 * {Marcin Lewandowski}[https://github.com/saepia]
 * doabit[https://github.com/doabit]
+* {Johannes Gorset}[https://github.com/jgorset]
 
 == ChangeLog
 

--- a/app/assets/javascripts/just_datetime_picker/nested_form_workaround.js
+++ b/app/assets/javascripts/just_datetime_picker/nested_form_workaround.js
@@ -6,6 +6,13 @@
 // We attach to a.button to catch a moment where user can potentially
 // add new field like this in a nested form.
 $(document).on('click', 'body.active_admin a.button', function() {
-  $('input.datepicker:not(.hasDatepicker)').datepicker();
+  $('input.datepicker:not(.hasDatePicker)').each(function() {
+    $input = $(this);
+
+    defaults = { dateFormat: 'yy-mm-dd' }
+    options = $input.data('datepicker-options');
+
+    $input.datepicker($.extend(defaults, options));
+  });
 });
 


### PR DESCRIPTION
This fixes an issue where date pickers would have their format changed from ActiveAdmin's default `yy-mm-dd` to jQuery UI's default `mm/dd/yy`, or any options set by the consumer, upon adding nested forms.